### PR TITLE
Features/orm joinedload

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, "src"))
 from logging.config import fileConfig
 
 from dotenv import load_dotenv
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import pool, engine_from_config
 
 from alembic import context
 from mc_postgres_db.models import Base  # Import your SQLAlchemy Base class

--- a/alembic/versions/01b93e270546_changing_primary_key_constraint_for_all_.py
+++ b/alembic/versions/01b93e270546_changing_primary_key_constraint_for_all_.py
@@ -6,7 +6,7 @@ Create Date: 2025-07-18 12:12:43.121783
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 # revision identifiers, used by Alembic.
 revision: str = "01b93e270546"

--- a/alembic/versions/0363c25292b7_adding_provider_asset_market_table.py
+++ b/alembic/versions/0363c25292b7_adding_provider_asset_market_table.py
@@ -6,7 +6,7 @@ Create Date: 2025-07-20 15:12:55.241449
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 import sqlalchemy as sa
 

--- a/alembic/versions/244d1250fc54_adding_tables_for_storing_asset_group_.py
+++ b/alembic/versions/244d1250fc54_adding_tables_for_storing_asset_group_.py
@@ -6,11 +6,11 @@ Create Date: 2025-09-20 13:20:58.430165
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "244d1250fc54"

--- a/alembic/versions/4056c087960a_.py
+++ b/alembic/versions/4056c087960a_.py
@@ -6,7 +6,7 @@ Create Date: 2025-06-23 18:38:27.569904
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 import sqlalchemy as sa
 

--- a/alembic/versions/49fa1eedaaa3_re_naming_column_author_to_authors_in_.py
+++ b/alembic/versions/49fa1eedaaa3_re_naming_column_author_to_authors_in_.py
@@ -6,7 +6,7 @@ Create Date: 2025-06-23 22:06:44.657403
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 from alembic import op
 

--- a/alembic/versions/5caaba3e0458_changing_column_s_in_tables_adding_.py
+++ b/alembic/versions/5caaba3e0458_changing_column_s_in_tables_adding_.py
@@ -6,7 +6,7 @@ Create Date: 2025-06-24 21:48:54.671456
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 import sqlalchemy as sa
 

--- a/alembic/versions/8b53c8e91507_adding_new_market_table_and_content_.py
+++ b/alembic/versions/8b53c8e91507_adding_new_market_table_and_content_.py
@@ -6,7 +6,7 @@ Create Date: 2025-06-23 18:45:51.916364
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 import sqlalchemy as sa
 

--- a/alembic/versions/a8684badeca3_adding_comments_content_changes_and_.py
+++ b/alembic/versions/a8684badeca3_adding_comments_content_changes_and_.py
@@ -6,7 +6,7 @@ Create Date: 2025-07-12 16:17:25.399285
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/alembic/versions/bca303faca0a_adding_asset_group_table.py
+++ b/alembic/versions/bca303faca0a_adding_asset_group_table.py
@@ -6,11 +6,11 @@ Create Date: 2025-09-20 14:49:12.958245
 
 """
 
-from typing import Sequence, Union
+from typing import Union, Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "bca303faca0a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,15 @@ packages = [
     { include = "mc_postgres_db/prefect/asyncio" },
     { include = "mc_postgres_db/testing" }
 ]
+
+[tool.ruff.lint]
+select = ["I", "F401"]  # Enable import sorting and unused imports
+
+[tool.ruff.lint.isort]
+# Sort imports by line length (shortest first)
+length-sort = true
+length-sort-straight = true
+
+[tool.ruff]
+# Enable automatic fixing of issues
+fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-postgres-db"
-version = "1.2.0"
+version = "1.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mc_postgres_db/models.py
+++ b/src/mc_postgres_db/models.py
@@ -1,8 +1,8 @@
 import datetime
 from typing import Optional
 
-from sqlalchemy import Engine, ForeignKey, MetaData, String, func, select
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
+from sqlalchemy import Engine, String, MetaData, ForeignKey, func, select
+from sqlalchemy.orm import Mapped, Session, DeclarativeBase, relationship, mapped_column
 
 
 class Base(DeclarativeBase):
@@ -80,8 +80,12 @@ class Asset(Base):
         nullable=True,
         comment="The identifier of the underlying asset",
     )
-    underlying_asset: Mapped[Optional["Asset"]] = relationship("Asset", remote_side=[id])
-    derived_assets: Mapped[list["Asset"]] = relationship("Asset", remote_side=[underlying_asset_id])
+    underlying_asset: Mapped[Optional["Asset"]] = relationship(
+        "Asset", remote_side=[id]
+    )
+    derived_assets: Mapped[list["Asset"]] = relationship(
+        "Asset", remote_side=[underlying_asset_id]
+    )
     is_active: Mapped[bool] = mapped_column(
         default=True, comment="Whether the asset is active"
     )
@@ -164,8 +168,12 @@ class Provider(Base):
         nullable=True,
         comment="The identifier of the underlying provider",
     )
-    underlying_provider: Mapped[Optional["Provider"]] = relationship("Provider", remote_side=[id])
-    derived_providers: Mapped[list["Provider"]] = relationship("Provider", remote_side=[underlying_provider_id])
+    underlying_provider: Mapped[Optional["Provider"]] = relationship(
+        "Provider", remote_side=[id]
+    )
+    derived_providers: Mapped[list["Provider"]] = relationship(
+        "Provider", remote_side=[underlying_provider_id]
+    )
     url: Mapped[Optional[str]] = mapped_column(
         String(1000), nullable=True, comment="The URL of the provider"
     )
@@ -743,7 +751,9 @@ class ProviderAssetGroupAttribute(Base):
         primary_key=True,
         comment="The identifier of the provider asset group",
     )
-    provider_asset_group: Mapped["ProviderAssetGroup"] = relationship("ProviderAssetGroup")
+    provider_asset_group: Mapped["ProviderAssetGroup"] = relationship(
+        "ProviderAssetGroup"
+    )
     lookback_window_seconds: Mapped[int] = mapped_column(
         nullable=False,
         primary_key=True,

--- a/src/mc_postgres_db/operations.py
+++ b/src/mc_postgres_db/operations.py
@@ -1,7 +1,7 @@
-from typing import Callable, Literal
+from typing import Literal, Callable
 
 import pandas as pd
-from sqlalchemy import Connection, Engine
+from sqlalchemy import Engine, Connection
 from sqlalchemy.dialects.postgresql import insert
 
 from mc_postgres_db.models import Base

--- a/src/mc_postgres_db/prefect/asyncio/tasks.py
+++ b/src/mc_postgres_db/prefect/asyncio/tasks.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
 import pandas as pd
-from prefect import get_run_logger, task
-from prefect.blocks.system import Secret
+from prefect import task, get_run_logger
 from sqlalchemy import Engine, create_engine
+from prefect.blocks.system import Secret
 
 from mc_postgres_db.operations import __set_data
 

--- a/src/mc_postgres_db/prefect/tasks.py
+++ b/src/mc_postgres_db/prefect/tasks.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
 import pandas as pd
-from prefect import get_run_logger, task
-from prefect.blocks.system import Secret
+from prefect import task, get_run_logger
 from sqlalchemy import Engine, create_engine
+from prefect.blocks.system import Secret
 
 from mc_postgres_db.operations import __set_data
 

--- a/src/mc_postgres_db/testing/utilities.py
+++ b/src/mc_postgres_db/testing/utilities.py
@@ -1,13 +1,13 @@
-import logging
 import os
+import logging
 import tempfile
 from contextlib import contextmanager
+from urllib.parse import urlparse
 
+from sqlalchemy import Engine, create_engine
+from prefect.settings import PREFECT_API_URL
 from prefect.blocks.system import Secret
 from prefect.testing.utilities import prefect_test_harness
-from prefect.settings import PREFECT_API_URL
-from sqlalchemy import Engine, create_engine
-from urllib.parse import urlparse
 
 import mc_postgres_db.models as models
 

--- a/tests/test_postgres_harness.py
+++ b/tests/test_postgres_harness.py
@@ -1,6 +1,6 @@
-import datetime as dt
 import os
 import sys
+import datetime as dt
 
 import pandas as pd
 
@@ -11,15 +11,15 @@ import pytest
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session
 
+from tests.utils import create_base_data
 from mc_postgres_db.models import (
     Base,
     ProviderAssetMarket,
 )
-from mc_postgres_db.prefect.asyncio.tasks import get_engine as get_engine_async
-from mc_postgres_db.prefect.asyncio.tasks import set_data as set_data_async
-from mc_postgres_db.prefect.tasks import get_engine, set_data
+from mc_postgres_db.prefect.tasks import set_data, get_engine
 from mc_postgres_db.testing.utilities import clear_database
-from tests.utils import create_base_data
+from mc_postgres_db.prefect.asyncio.tasks import set_data as set_data_async
+from mc_postgres_db.prefect.asyncio.tasks import get_engine as get_engine_async
 
 
 def test_engine_is_mocked():

--- a/tests/test_provider_asset_group.py
+++ b/tests/test_provider_asset_group.py
@@ -1,6 +1,6 @@
-import datetime as dt
 import os
 import sys
+import datetime as dt
 
 import numpy as np
 import pandas as pd
@@ -13,18 +13,18 @@ import statsmodels.api as sm
 from sqlalchemy.orm import Session
 from statsmodels.regression.rolling import RollingOLS
 
-from mc_postgres_db.models import (
-    AssetGroupType,
-    Provider,
-    ProviderAssetGroup,
-    ProviderAssetGroupAttribute,
-    ProviderAssetGroupMember,
-    ProviderAssetMarket,
-)
-from mc_postgres_db.prefect.asyncio.tasks import get_engine as get_engine_async
-from mc_postgres_db.prefect.tasks import set_data
 from tests.utils import create_base_data
+from mc_postgres_db.models import (
+    Provider,
+    AssetGroupType,
+    ProviderAssetGroup,
+    ProviderAssetMarket,
+    ProviderAssetGroupMember,
+    ProviderAssetGroupAttribute,
+)
+from mc_postgres_db.prefect.tasks import set_data
 from mc_postgres_db.testing.utilities import clear_database
+from mc_postgres_db.prefect.asyncio.tasks import get_engine as get_engine_async
 
 
 def create_default_asset_group_type(session: Session) -> AssetGroupType:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import Session
 
 from mc_postgres_db.models import (
     Asset,
-    AssetType,
     Provider,
+    AssetType,
     ProviderType,
 )
 from mc_postgres_db.testing.utilities import clear_database

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "mc-postgres-db"
-version = "1.2.0"
+version = "1.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds comprehensive ORM relationships enabling efficient `joinedload` across models and asset group management, updates README with examples, expands tests, and bumps config/version.
> 
> - **Models (`src/mc_postgres_db/models.py`)**:
>   - Add explicit ORM relationships on `Asset`, `Provider`, `ProviderAsset`, `ProviderAssetOrder`, `ProviderAssetMarket`, `ProviderContent`, `ProviderContentSentiment`, `AssetContent`, `ProviderAssetGroup`, `ProviderAssetGroupMember`, and `ProviderAssetGroupAttribute` to support efficient `joinedload` and clearer navigation.
>   - Introduce `AssetGroupType` linkage and refine group/member relationships and ordering.
> - **Docs (`README.md`)**:
>   - Add sections and examples for basic queries, `joinedload` usage, and asset group creation/usage; document optimized unidirectional relationships.
> - **Tests (`tests/*`)**:
>   - Add/expand tests for asset group types, member ordering, composite keys, relationships, and async/sync data ops.
> - **Config/Build**:
>   - Bump version to `1.2.1`; add Ruff lint config; minor import order cleanups; update lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6298cb4e94ff1a4708291ac05fc07fb3b2e6187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->