### PR TITLE
Fix overlaps parameter in TransactionGroupMember relationships

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-postgres-db"
-version = "1.4.3"
+version = "1.4.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mc_postgres_db/models.py
+++ b/src/mc_postgres_db/models.py
@@ -994,7 +994,7 @@ class TransactionGroupMember(Base):
         comment="The identifier of the transaction group",
     )
     transaction_group: Mapped["TransactionGroup"] = relationship(
-        "TransactionGroup", overlaps="transactions"
+        "TransactionGroup", overlaps="groups"
     )
     portfolio_transaction_id: Mapped[int] = mapped_column(
         ForeignKey("portfolio_transaction.id"),
@@ -1003,7 +1003,7 @@ class TransactionGroupMember(Base):
         comment="The identifier of the portfolio transaction",
     )
     portfolio_transaction: Mapped["PortfolioTransaction"] = relationship(
-        "PortfolioTransaction", overlaps="groups"
+        "PortfolioTransaction", overlaps="transactions"
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         nullable=False,


### PR DESCRIPTION
## Summary
Fixed incorrect `overlaps` parameter values in the `TransactionGroupMember` model's SQLAlchemy relationship definitions. The overlaps parameters were swapped between the two relationships, causing potential issues with relationship configuration.

## Changes
- Updated `transaction_group` relationship: changed `overlaps="transactions"` to `overlaps="groups"` to correctly reference the overlapping relationship name in the `TransactionGroup` model
- Updated `portfolio_transaction` relationship: changed `overlaps="groups"` to `overlaps="transactions"` to correctly reference the overlapping relationship name in the `PortfolioTransaction` model

## Details
The `overlaps` parameter in SQLAlchemy relationships is used to suppress warnings about multiple relationship paths between the same entities. The parameter values must match the actual relationship attribute names on the related models. This fix ensures the correct relationship names are referenced, preventing potential SQLAlchemy warnings and ensuring proper relationship configuration.

https://claude.ai/code/session_01AF5DSAgFNMxTwrQ5CDUHsq