### PR TITLE
Fix TransactionGroupMember overlaps and bump to 1.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-postgres-db"
-version = "1.4.4"
+version = "1.4.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mc_postgres_db/models.py
+++ b/src/mc_postgres_db/models.py
@@ -994,7 +994,7 @@ class TransactionGroupMember(Base):
         comment="The identifier of the transaction group",
     )
     transaction_group: Mapped["TransactionGroup"] = relationship(
-        "TransactionGroup", overlaps="groups"
+        "TransactionGroup", overlaps="groups,transactions"
     )
     portfolio_transaction_id: Mapped[int] = mapped_column(
         ForeignKey("portfolio_transaction.id"),
@@ -1003,7 +1003,7 @@ class TransactionGroupMember(Base):
         comment="The identifier of the portfolio transaction",
     )
     portfolio_transaction: Mapped["PortfolioTransaction"] = relationship(
-        "PortfolioTransaction", overlaps="transactions"
+        "PortfolioTransaction", overlaps="groups,transactions"
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         nullable=False,

--- a/tests/test_mapper_config.py
+++ b/tests/test_mapper_config.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import warnings
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, "src"))
+
+from sqlalchemy.exc import SAWarning
+from sqlalchemy.orm import configure_mappers
+
+import mc_postgres_db.models  # noqa: F401  (imported for side-effect: registers mappers)
+
+
+def test_configure_mappers_emits_no_sawarning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SAWarning)
+        configure_mappers()

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "mc-postgres-db"
-version = "1.4.2"
+version = "1.4.5"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Each direct relationship on `TransactionGroupMember` (`transaction_group`, `portfolio_transaction`) conflicts with **both** secondary-style relationships — `PortfolioTransaction.groups` and `TransactionGroup.transactions` — so each `overlaps=` must list both names. The previous values listed only one, so SQLAlchemy still emitted an `SAWarning` at `configure_mappers()` time for the unlisted conflict (visible as noisy warnings in downstream notebooks).
- Bumps version to `1.4.5` so the fix can be republished to PyPI.
- Adds `tests/test_mapper_config.py` as a regression test that promotes `SAWarning` → error during `configure_mappers()`, so a future regression fails CI instead of leaking into downstream consumers.

## Test plan
- [x] `uv run pytest tests/test_mapper_config.py` passes locally with the fix
- [x] Verified the same test **fails** with the prior `overlaps="groups"` / `overlaps="transactions"` values (catches the bug)
- [x] CI green
- [x] After merge: tag `v1.4.5` to trigger the release workflow